### PR TITLE
[BUGFIX] Make EXT:solrfal installable again due of 11.5 constraints in EXT:solrfal

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
   "name": "dkd/apache-solr-for-typo3-dev-distribution",
   "description": "TYPO3 CMS Base Distribution for EXT:solr* development and testing.",
   "license": "GPL-2.0-or-later",
+  "type": "project",
   "repositories": {
     "0": {
       "type": "path",
@@ -32,6 +33,13 @@
       }
     }
   },
+  "config": {
+    "allow-plugins": true,
+    "platform": {
+      "php": "8.1"
+    },
+    "sort-packages": true
+  },
   "require": {
     "ext-dom": "*",
     "ext-json": "*",
@@ -40,7 +48,7 @@
     "helhum/typo3-console": "~7.1.2",
     "typo3-console/composer-auto-commands": "0.5.2",
     "dkd/apache-solr-for-typo3-sitepackage": "11.5",
-    "apache-solr-for-typo3/solr": "11.5"
+    "apache-solr-for-typo3/solr": "11.5 as 11.5.99"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5",
@@ -80,11 +88,5 @@
       "@import-not-exportable-by-impexp-once",
       "@sitepackage-scripts"
     ]
-  },
-  "config": {
-    "allow-plugins": {
-      "typo3/cms-composer-installers": true,
-      "typo3/class-alias-loader": true
-    }
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a36dc087d123a6dbb9fa8415e998d006",
+    "content-hash": "588724790b35cefdfd85f073248dfaed",
     "packages": [
         {
             "name": "apache-solr-for-typo3/solr",
@@ -10305,7 +10305,14 @@
             "time": "2023-08-02T16:11:00+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "package": "apache-solr-for-typo3/solr",
+            "version": "11.5.0.0",
+            "alias": "11.5.99",
+            "alias_normalized": "11.5.99.0"
+        }
+    ],
     "minimum-stability": "stable",
     "stability-flags": [],
     "prefer-stable": false,
@@ -10316,5 +10323,8 @@
         "ext-pdo": "*"
     },
     "platform-dev": [],
+    "platform-overrides": {
+        "php": "8.1"
+    },
     "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
Fixes the constraint troubles within `ddev solr:enable solrfal`