### PR TITLE
[BUGFIX] Make sure that logs directory exists in ddev command

### DIFF
--- a/.ddev/commands/web/examples-nutch
+++ b/.ddev/commands/web/examples-nutch
@@ -81,6 +81,10 @@ if [[ $1 == "--website" ]]; then
   exit 1
 fi
 
+if [[ ! -d "${TYPO3_NUTCH_DISTRIBUTION_PATH}/logs" ]]; then
+  mkdir "${TYPO3_NUTCH_DISTRIBUTION_PATH}/logs"
+fi
+
 cd "${TYPO3_NUTCH_DISTRIBUTION_PATH}/logs" || exit 7
 
 if [[ $1 == *--website=* ]]; then


### PR DESCRIPTION
This patch make sure that the `logs` directory exists in `ddev solr:examples:nutch` command.

The logs directory is not part of the current Nutch plugin releases.