### PR TITLE
[TASK] Backport ddev clone auto-rename and README pull instructions from main

### DIFF
--- a/.ddev/commands/host/clone
+++ b/.ddev/commands/host/clone
@@ -11,6 +11,8 @@ fi
 if [ ! -d "packages/ext-$EXT_SOLR_PLUGIN_NAME" ];then
   git clone git@github.com:TYPO3-Solr/ext-"$EXT_SOLR_PLUGIN_NAME".git packages/ext-"$EXT_SOLR_PLUGIN_NAME" \
   || git clone https://github.com/TYPO3-Solr/ext-"$EXT_SOLR_PLUGIN_NAME".git packages/ext-"$EXT_SOLR_PLUGIN_NAME"
+  git remote rename origin upstream 2>/dev/null || true
+  git -C packages/ext-"$EXT_SOLR_PLUGIN_NAME" remote rename origin upstream
 else
   echo "EXT:$EXT_SOLR_PLUGIN_NAME repo presents in packages/ext-$EXT_SOLR_PLUGIN_NAME."
   echo "If needed, checkout the desired branch of ext-$EXT_SOLR_PLUGIN_NAME and update composer manually."

--- a/README.md
+++ b/README.md
@@ -5,11 +5,32 @@
 >
 > **Only difference on this branch:** the DDEV project is named **`solr-13.1`** (URLs are `https://solr-13.1.ddev.site/…`).
 >
-> **Check this branch out into its own directory and open it as a separate IDE project** — a `main` and a `release-13.1.x` checkout cannot live in the same folder. Maintainers typically use a layout like:
+> **Check this branch out into its own directory and open it as a separate IDE project** — a `main` and a `release-13.1.x` checkout cannot live in the same folder. Clone with an explicit target path, for example:
+>
+> ```bash
+> git clone -b release-13.1.x git@github.com:TYPO3-Solr/solr-ddev-site.git ~/PhpstormProjects/solr-ddev-site.13.1
+> cd ~/PhpstormProjects/solr-ddev-site.13.1
+> ddev start
+> ```
+>
+> Maintainers typically use this layout for parallel checkouts:
 >
 > ```
-> ~/PhpstormProjects/solr-ddev-site.main    # main branch  → DDEV name: solr-ddev-site
-> ~/PhpstormProjects/solr-ddev-site.13.1    # this branch → DDEV name: solr-13.1
+> ~/PhpstormProjects/solr-ddev-site.main    # main branch       → DDEV name: solr-ddev-site
+> ~/PhpstormProjects/solr-ddev-site.13.1    # release-13.1.x    → DDEV name: solr-13.1
 > ```
 >
 > Both DDEV projects can then run simultaneously, each with its own containers and URLs.
+
+## Keep this branch up to date
+
+`ddev clone` sets `https://github.com/TYPO3-Solr/…` as `upstream` automatically on first clone (for both `solr-ddev-site` and `packages/ext-solr`). Pull upstream changes regularly to stay in sync with `release-13.1.x`:
+
+```bash
+git pull --rebase upstream release-13.1.x
+cd packages/ext-solr && git pull --rebase upstream release-13.1.x
+cd ../../
+ddev start
+```
+
+> **Linear history:** EXT:solr* repositories use a linear history — always `git rebase`, never `git merge`.


### PR DESCRIPTION
Two small follow-ups to the recent docs/scripts backport (PR #81) that keep the upstream-pull workflow aligned with the convention used on main:

.ddev/commands/host/clone
- Rename `origin` → `upstream` automatically on first clone for both `solr-ddev-site` itself and the cloned `packages/ext-<addon>` repository. This matches the `origin = your fork, upstream = TYPO3-Solr` convention documented on main and used by the maintainers' fork workflow.

README.md
- Add a "Keep this branch up to date" section with the exact commands to rebase-pull both `solr-ddev-site` and `packages/ext-solr` from `upstream release-13.1.x`, plus a reminder that EXT:solr* repositories use a linear history (rebase, never merge).